### PR TITLE
fix: updates for machines and charms

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ This table tracks progress through the redesign of the Juju client API:
 | KeyManager           | DeleteKeys                      |                                                                 |
 | KeyManager           | ImportKeys                      |                                                                 |
 | KeyManager           | ListKeys                        |                                                                 |
-| MachineManager       | AddMachines                     |                                                                 |
-| MachineManager       | DestroyMachineWithParams        |                                                                 |
+| MachineManager       | AddMachines                     | `POST /models/{namespace}/{model}/machines`                     |
+| MachineManager       | DestroyMachineWithParams        | `DELETE /models/{namespace}/{model}/machines/{machine-id}`      |
 | MachineManager       | GetUpgradeSeriesMessages        |                                                                 |
 | MachineManager       | InstanceTypes                   |                                                                 |
 | MachineManager       | ProvisioningScript              |                                                                 |

--- a/README.md
+++ b/README.md
@@ -176,14 +176,14 @@ This table tracks progress through the redesign of the Juju client API:
 | KeyManager           | ListKeys                        |                                                                 |
 | MachineManager       | AddMachines                     | `POST /models/{namespace}/{model}/machines`                     |
 | MachineManager       | DestroyMachineWithParams        | `DELETE /models/{namespace}/{model}/machines/{machine-id}`      |
-| MachineManager       | GetUpgradeSeriesMessages        |                                                                 |
+| MachineManager       | GetUpgradeSeriesMessages        | N/A                                                             |
 | MachineManager       | InstanceTypes                   |                                                                 |
 | MachineManager       | ProvisioningScript              |                                                                 |
 | MachineManager       | RetryProvisioning               |                                                                 |
-| MachineManager       | UpgradeSeriesComplete           |                                                                 |
-| MachineManager       | UpgradeSeriesPrepare            |                                                                 |
-| MachineManager       | UpgradeSeriesValidate           |                                                                 |
-| MachineManager       | WatchUpgradeSeriesNotifications |                                                                 |
+| MachineManager       | UpgradeSeriesComplete           | N/A                                                             |
+| MachineManager       | UpgradeSeriesPrepare            | N/A                                                             |
+| MachineManager       | UpgradeSeriesValidate           | N/A                                                             |
+| MachineManager       | WatchUpgradeSeriesNotifications | N/A                                                             |
 | MetricsDebug         | GetMetrics                      |                                                                 |
 | MetricsDebug         | SetMeterStatus                  |                                                                 |
 | ModelConfig          | GetModelConstraints             | `GET /models/{namespace}/{model}`                               |
@@ -194,14 +194,14 @@ This table tracks progress through the redesign of the Juju client API:
 | ModelConfig          | Sequences                       |                                                                 |
 | ModelConfig          | SetModelConstraints             | `PATCH /models/{namespace}/{model}`                             |
 | ModelConfig          | SetSLALevel                     | N/A                                                             |
-| ModelGeneration      | AbortBranch                     |                                                                 |
-| ModelGeneration      | AddBranch                       |                                                                 |
-| ModelGeneration      | BranchInfo                      |                                                                 |
-| ModelGeneration      | CommitBranch                    |                                                                 |
-| ModelGeneration      | HasActiveBranch                 |                                                                 |
-| ModelGeneration      | ListCommits                     |                                                                 |
-| ModelGeneration      | ShowCommit                      |                                                                 |
-| ModelGeneration      | TrackBranch                     |                                                                 |
+| ModelGeneration      | AbortBranch                     | N/A                                                             |
+| ModelGeneration      | AddBranch                       | N/A                                                             |
+| ModelGeneration      | BranchInfo                      | N/A                                                             |
+| ModelGeneration      | CommitBranch                    | N/A                                                             |
+| ModelGeneration      | HasActiveBranch                 | N/A                                                             |
+| ModelGeneration      | ListCommits                     | N/A                                                             |
+| ModelGeneration      | ShowCommit                      | N/A                                                             |
+| ModelGeneration      | TrackBranch                     | N/A                                                             |
 | ModelManager         | ChangeModelCredential           | `PATCH /models/{namespace}/{model}`                             |
 | ModelManager         | CreateModel                     | `POST /models`                                                  |
 | ModelManager         | DestroyModels                   | `DELETE /models/{namespace}/{model}`                            |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This table tracks progress through the redesign of the Juju client API:
 | Application          | SetCharm                        | `PATCH /models/{namespace}/{model}/apps/{app}/refresh`          |
 | Application          | SetConfigs                      | `PATCH /models/{namespace}/{model}/apps/{app}`                  |
 | Application          | SetConstraints                  | `PATCH /models/{namespace}/{model}/apps/{app}`                  |
-| Application          | SetMetricCredentials            |                                                                 |
+| Application          | SetMetricCredentials            | N/A                                                             |
 | Application          | SetRelationsSuspended           |                                                                 |
 | Application          | Unexpose                        | `PATCH /models/{namespace}/{model}/apps/{app}`                  |
 | Application          | UnitsInfo                       |                                                                 |
@@ -184,8 +184,8 @@ This table tracks progress through the redesign of the Juju client API:
 | MachineManager       | UpgradeSeriesPrepare            | N/A                                                             |
 | MachineManager       | UpgradeSeriesValidate           | N/A                                                             |
 | MachineManager       | WatchUpgradeSeriesNotifications | N/A                                                             |
-| MetricsDebug         | GetMetrics                      |                                                                 |
-| MetricsDebug         | SetMeterStatus                  |                                                                 |
+| MetricsDebug         | GetMetrics                      | N/A                                                             |
+| MetricsDebug         | SetMeterStatus                  | N/A                                                             |
 | ModelConfig          | GetModelConstraints             | `GET /models/{namespace}/{model}`                               |
 | ModelConfig          | ModelGet                        | `GET /models/{namespace}/{model}`                               |
 | ModelConfig          | ModelSet                        | `PATCH /models/{namespace}/{model}`                             |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This table tracks progress through the redesign of the Juju client API:
 | Application          | DestroyUnit                     | `PATCH /models/{namespace}/{model}/apps/{app}/scale`            |
 | Application          | Expose                          | `PATCH /models/{namespace}/{model}/apps/{app}`                  |
 | Application          | Get                             | `GET /models/{namespace}/{model}/apps/{app}`                    |
+| Application          | GetCharmURLOrigin               |                                                                 |
 | Application          | GetConfig                       | `GET /models/{namespace}/{model}/apps/{app}`                    |
 | Application          | GetConstraints                  | `GET /models/{namespace}/{model}/apps/{app}`                    |
 | Application          | Leader                          |                                                                 |
@@ -112,6 +113,7 @@ This table tracks progress through the redesign of the Juju client API:
 | Bundle               | GetChanges                      |                                                                 |
 | Bundle               | GetChangesMapArgs               |                                                                 |
 | Charms               | AddCharm                        |                                                                 |
+| Charms               | CharmInfo                       |                                                                 |
 | Charms               | CheckCharmPlacement             |                                                                 |
 | Charms               | GetDownloadInfos                |                                                                 |
 | Charms               | IsMetered                       |                                                                 |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -738,6 +738,32 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /models/{namespace}/{model}/machines:
+    get:
+      tags:
+        - model
+      summary: Get a listing of all the machines in a model
+      description: |
+        Returns just the information about what machines exist in this model.
+        Likely a minimal amount of information (equivalent for `juju machines`,
+        but not the detail that you could get with `juju show-machine X`)
+      operationId: getMachines
+      parameters:
+        - $ref: "#/components/parameters/Namespace"
+        - $ref: "#/components/parameters/Model"
+      responses:
+        "200":
+          description: Status information about the requested model.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MachineList"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /models/{namespace}/{model}/status:
     get:
       tags:
@@ -1738,6 +1764,11 @@ components:
             type: string
         virt-type:
           type: string
+      additionalProperties: false
+    MachineList:
+      type: array
+      items:
+        $ref: "#/components/schemas/ModelMachine"
       additionalProperties: false
     Model:
       description: Information about a given model.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -621,11 +621,11 @@ paths:
                 #  we should just make it clear fields as part of a multi-part POST
                 charmURL:
                   type: string
-              # $ref: "#/components/schema/Charm"
+                  # $ref: "#/components/schema/Charm"
           application/zip:
             schema:
-                type: string
-                format: binary
+              type: string
+              format: binary
         required: true
       responses:
         "201":
@@ -636,13 +636,15 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /models/{namespace}/{model}/charms/{charmname}:
+  /models/{namespace}/{model}/charms/{charm-name}:
+    # TODO: jam 2025-03-04 this needs a revision of some sort, to disambiguate revisions of the charm over time
+    get:
       tags:
         - charms
       summary: Upload a charm blob to the juju controller so that you can later deploy the charm
       description: |
         Download the content of an uploaded charm
-      operationId: uploadCharm
+      operationId: downloadCharm
       parameters:
         - $ref: "#/components/parameters/Namespace"
         - $ref: "#/components/parameters/Model"
@@ -656,7 +658,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /models/{namespace}/{model}/charms/{charm}/resources:
+  /models/{namespace}/{model}/charms/{charm-name}/resources:
+    # TODO: jam 2025-03-04 this needs a revision of some sort, to disambiguate revisions of the resources over time
     post:
       tags:
         - charms
@@ -667,16 +670,17 @@ paths:
         To deploy a local charm, first upload charms and resources, getting
         references to them, which can then be supplied when creating an
         application.
-      operationId: uploadCharm
+      operationId: charmResources
       parameters:
         - $ref: "#/components/parameters/Namespace"
         - $ref: "#/components/parameters/Model"
+        - $ref: "#/components/parameters/CharmName"
       requestBody:
         content:
           application/zip:
             schema:
-                type: string
-                format: binary
+              type: string
+              format: binary
         required: true
       responses:
         "201":
@@ -2559,18 +2563,18 @@ components:
         type: array
         items:
           type: string
-    Cloud:
-      in: path
-      name: cloud
-      required: true
-      description: The name of a cloud in the controller.
-      schema:
-        type: string
     CharmName:
       in: path
       name: charm-name
       required: true
       description: The name of the Charm.
+      schema:
+        type: string
+    Cloud:
+      in: path
+      name: cloud
+      required: true
+      description: The name of a cloud in the controller.
       schema:
         type: string
     DestroyStorage:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30,7 +30,7 @@ info:
   version: "1.0"
 externalDocs:
   description: Find out more about Juju.
-  url: http://juju.is/docs
+  url: https://juju.is/docs
 servers:
   - url: https://localhost:17777/api/v1
 tags:
@@ -46,6 +46,11 @@ tags:
     externalDocs:
       description: Find out more about Juju clouds.
       url: https://juju.is/docs/olm/manage-clouds
+  - name: machine
+    description: Manage Juju machines
+    externalDocs:
+      description: Find out more about Juju machines.
+      url: https://juju.is/docs/olm/manage-models
   - name: model
     description: Manage Juju models
     externalDocs:
@@ -753,11 +758,84 @@ paths:
         - $ref: "#/components/parameters/Model"
       responses:
         "200":
-          description: Status information about the requested model.
+          description: Status information about the requested machine.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/MachineList"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    post:
+      tags:
+        - model
+      summary: Add a machine to the model.
+      description: |
+        Returns the machines' object including the machines' url.
+        Likely a minimal amount of information (equivalent to `juju add-machine`)
+      operationId: postMachines
+      parameters:
+        - $ref: "#/components/parameters/Namespace"
+        - $ref: "#/components/parameters/Model"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MachineCreateArgs"
+          required: true
+      responses:
+        "201":
+          $ref: "#/components/responses/EntityCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /models/{namespace}/{model}/machines/{machine-id}:
+    get:
+      tags:
+        - machine
+      description: |
+        Returns details of the specified machine.
+      operationId: getMachine
+      parameters:
+        - $ref: "#/components/parameters/Namespace"
+        - $ref: "#/components/parameters/Model"
+        - $ref: "#/components/parameters/MachineID"
+      responses:
+        "200":
+          description: Details of the requested machine.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ModelMachine"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - machine
+      summary: Delete a machine.
+      description: |
+        Permanently removes a machine from the controller.
+      operationId: deleteMachine
+      parameters:
+        - $ref: "#/components/parameters/Namespace"
+        - $ref: "#/components/parameters/Model"
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/MachineID"
+        - $ref: "#/components/parameters/Wait"
+        - $ref: "#/components/parameters/KeepInstance"
+      responses:
+        "200":
+          $ref: "#/components/responses/EmptySyncResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -1743,6 +1821,41 @@ components:
           type: string
       required:
         - application
+    MachineCreateArgs:
+      type: object
+      properties:
+        base:
+          $ref: "#/components/schemas/Base"
+        constraints:
+          $ref: "#/components/schemas/Constraints"
+        storage-constraints:
+          description: The credential to use when creating the new model.
+          type: string
+        placement:
+          description: The name of the new model.
+          type: string
+        parent-id:
+          description: Identifier of the owner of the new model.
+          type: string
+        container-type:
+          description: Identifier of the cloud region in which to create the model.
+          type: string
+        instance-id:
+          description: Identifier of the cloud region in which to create the model.
+          type: string
+        nonce:
+          description: Identifier of the cloud region in which to create the model.
+          type: string
+        addresses:
+          description: Identifier of the cloud region in which to create the model.
+          type: string
+        hardware-characteristics:
+          description: Identifier of the cloud region in which to create the model.
+          type: string
+      additionalProperties: false
+      required:
+        - name
+        - owner
     MachineHardware:
       type: object
       properties:
@@ -2643,6 +2756,20 @@ components:
       schema:
         # TODO: jam 2025-02-20 should this be an opaque string instead?
         type: integer
+    KeepInstance:
+      in: query
+      name: keep-instance
+      required: false
+      schema:
+        type: boolean
+        default: false
+    MachineID:
+      in: path
+      name: machine-id
+      required: true
+      description: The id of a machine in the model.
+      schema:
+        type: string
     MaxWait:
       in: query
       name: max-wait
@@ -2767,6 +2894,13 @@ components:
       description: Username of a user on the controller.
       schema:
         type: string
+    Wait:
+      in: query
+      name: wait
+      required: false
+      schema:
+        type: boolean
+        default: true
   responses:
     BadRequest:
       description: Bad request.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -641,30 +641,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /models/{namespace}/{model}/charms/{charm-name}:
-    # TODO: jam 2025-03-04 this needs a revision of some sort, to disambiguate revisions of the charm over time
-    get:
-      tags:
-        - charms
-      summary: Upload a charm blob to the juju controller so that you can later deploy the charm
-      description: |
-        Download the content of an uploaded charm
-      operationId: downloadCharm
-      parameters:
-        - $ref: "#/components/parameters/Namespace"
-        - $ref: "#/components/parameters/Model"
-        - $ref: "#/components/parameters/CharmName"
-      responses:
-        "201":
-          $ref: "#/components/responses/EntityCreated"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-  /models/{namespace}/{model}/charms/{charm-name}/resources:
-    # TODO: jam 2025-03-04 this needs a revision of some sort, to disambiguate revisions of the resources over time
+  /models/{namespace}/{model}/charms/{charm-name}/{charm-rev}/resources:
     post:
       tags:
         - charms
@@ -675,13 +652,23 @@ paths:
         To deploy a local charm, first upload charms and resources, getting
         references to them, which can then be supplied when creating an
         application.
-      operationId: charmResources
+      operationId: uploadCharmResources
       parameters:
         - $ref: "#/components/parameters/Namespace"
         - $ref: "#/components/parameters/Model"
         - $ref: "#/components/parameters/CharmName"
+        - $ref: "#/components/parameters/CharmRevision"
       requestBody:
         content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                # TODO: jam 2025-03-13 these are rough approximations of what we need to supply
+                resource:
+                  type: string
+                sha256:
+                  type: string
           application/zip:
             schema:
               type: string
@@ -721,7 +708,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /models/{namespace}/{model}/integrations/{integration}:
+  /models/{namespace}/{model}/integrations/{integration-id}:
     # TODO: jam 2025-02-20 There should almost definitely be a GET possible for
     # an integration, plausibly to get you the current content of that relation
     delete:
@@ -733,7 +720,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/Namespace"
         - $ref: "#/components/parameters/Model"
-        - $ref: "#/components/parameters/Integration"
+        - $ref: "#/components/parameters/IntegrationID"
       responses:
         "200":
           $ref: "#/components/responses/EmptySyncResponse"
@@ -2711,6 +2698,13 @@ components:
       description: The name of the Charm.
       schema:
         type: string
+    CharmRevision:
+      in: path
+      name: charm-rev
+      required: true
+      description: The revision of the Charm.
+      schema:
+        type: string
     Cloud:
       in: path
       name: cloud
@@ -2746,9 +2740,9 @@ components:
       schema:
         type: boolean
         default: false
-    Integration:
+    IntegrationID:
       in: path
-      name: integration
+      name: integration-id
       required: true
       schema:
         # TODO: jam 2025-02-20 should this be an opaque string instead?
@@ -2895,6 +2889,7 @@ components:
       in: query
       name: wait
       required: false
+      description: Wait for hooks to complete before moving forward with removing the entity.
       schema:
         type: boolean
         default: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -785,7 +785,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/MachineCreateArgs"
-          required: true
+        required: true
       responses:
         "201":
           $ref: "#/components/responses/EntityCreated"
@@ -1853,9 +1853,6 @@ components:
           description: Identifier of the cloud region in which to create the model.
           type: string
       additionalProperties: false
-      required:
-        - name
-        - owner
     MachineHardware:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1327,9 +1327,6 @@ components:
           additionalProperties:
             $ref: "#/components/schemas/StorageConstraints"
       additionalProperties: false
-      required:
-        - application
-        - charm-name
     ApplicationScale:
       type: object
       properties:
@@ -1866,7 +1863,6 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/ModelMachine"
-      additionalProperties: false
     Model:
       description: Information about a given model.
       type: object
@@ -2391,7 +2387,7 @@ components:
             $ref: "#/components/schemas/Secret"
       additionalProperties: false
       required:
-        - spaces
+        - secrets
     SecretRevision:
       type: object
       properties:


### PR DESCRIPTION
This is a rollup of a few of the changes that I made towards progressing a 'charms/' endpoint and a 'machines/' endpoint. Some of these were also Heather's changes that we merged into my branch.

We also noticed that all of the ModelGeneration functionality wasn't going to be in 4.0 so we don't need to worry about them.